### PR TITLE
Close files opened during validation

### DIFF
--- a/bag.go
+++ b/bag.go
@@ -3,7 +3,6 @@ package go_bagit
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -32,7 +31,7 @@ func ValidateBag(bagLocation string, fast bool, complete bool) error {
 	}
 
 	//validate ant manifest files
-	bagFiles, err := ioutil.ReadDir(bagLocation)
+	bagFiles, err := os.ReadDir(bagLocation)
 	if err != nil {
 		return err
 	}
@@ -71,7 +70,7 @@ func CreateBag(inputDir string, algorithm string, numProcesses int) error {
 	log.Printf("- INFO - Creating Bag for directory %s", inputDir)
 
 	//create a slice of files
-	filesToBag, err := ioutil.ReadDir(inputDir)
+	filesToBag, err := os.ReadDir(inputDir)
 	if err != nil {
 		return err
 	}
@@ -189,7 +188,7 @@ func AddFileToBag(bagLocation string, file string) error {
 	targetFile.Close()
 
 	//locate any tag manifest files
-	bagFiles, err := ioutil.ReadDir(bagLocation)
+	bagFiles, err := os.ReadDir(bagLocation)
 	if err != nil {
 		return err
 	}

--- a/manifest.go
+++ b/manifest.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -145,7 +144,7 @@ func CreateManifest(manifestName string, bagLoc string, algorithm string, numPro
 
 func CreateTagManifest(inputDir string, algorithm string, numProcesses int) error {
 
-	files, err := ioutil.ReadDir(inputDir)
+	files, err := os.ReadDir(inputDir)
 	if err != nil {
 		return err
 	}

--- a/oxum.go
+++ b/oxum.go
@@ -39,6 +39,7 @@ func GetOxum(bagLocation string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
 


### PR DESCRIPTION
I've found that the validation code path was leaving some files opened.

I've also replaced `io.ReadDir` with `os.ReadDir` (see the [deprecation notice](https://go.dev/doc/go1.16#ioutil)).