### PR TITLE
Update metadata tags

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -104,21 +104,21 @@ type StandardTagSet struct {
 
 func GetStandardTags() StandardTagSet {
 	standardTags := StandardTagSet{}
-	standardTags.BagSoftwareAgent = "Bag_Software_Agent"
-	standardTags.SourceOrganization = "Source_Organization"
-	standardTags.OrganizationAddress = "Organization_Address"
-	standardTags.ContactName = "Contact_Name"
-	standardTags.ContactPhone = "Contact_Phone"
-	standardTags.ContactEmail = "Contact_email"
-	standardTags.ExternalDescription = "External_Description"
-	standardTags.ExternalIdentifier = "External_Identifier"
-	standardTags.BagSize = "Bag_Size"
-	standardTags.BaggingDate = "Bagging_Date"
-	standardTags.PayloadOxum = "Payload_Oxum"
-	standardTags.BagCount = "Bag_Count"
-	standardTags.BagGroupIdentifier = "Bag_Group_Identifier"
-	standardTags.InternalSenderIdentifier = "Internal_Sender_Identifier"
-	standardTags.InternalSenderDescription = "Internal_Sender_Description"
+	standardTags.BagSoftwareAgent = "Bag-Software-Agent"
+	standardTags.SourceOrganization = "Source-Organization"
+	standardTags.OrganizationAddress = "Organization-Address"
+	standardTags.ContactName = "Contact-Name"
+	standardTags.ContactPhone = "Contact-Phone"
+	standardTags.ContactEmail = "Contact-email"
+	standardTags.ExternalDescription = "External-Description"
+	standardTags.ExternalIdentifier = "External-Identifier"
+	standardTags.BagSize = "Bag-Size"
+	standardTags.BaggingDate = "Bagging-Date"
+	standardTags.PayloadOxum = "Payload-Oxum"
+	standardTags.BagCount = "Bag-Count"
+	standardTags.BagGroupIdentifier = "Bag-Group-Identifier"
+	standardTags.InternalSenderIdentifier = "Internal-Sender-Identifier"
+	standardTags.InternalSenderDescription = "Internal-Sender-Description"
 	return standardTags
 }
 


### PR DESCRIPTION
Hello @dmnyu :wave: 

I'm using `go-bagit` to create and validate bags and I noticed a mismatch in the way the `Payload-Oxum` tag is created and handled in validation.

The error can be reproduced like this:

```bash
replaceafill@vm1:~/go-bagit$ cp -r test/bag-me/ /tmp/mybag
replaceafill@vm1:~/go-bagit$ go run ./main/ create --algorithm sha256 --input-dir /tmp/mybag
2022/12/07 13:17:47 - INFO - Creating Bag for directory /tmp/mybag
2022/12/07 13:17:47 - INFO - Creating data directory
2022/12/07 13:17:47 - INFO - Moving /tmp/mybag/test.txt to /tmp/mybag/data/test.txt
2022/12/07 13:17:47 - INFO - Using 1 processes to generate manifests: sha256
2022/12/07 13:17:47 - INFO - Generating manifest lines for file /tmp/mybag/data/test.txt
2022/12/07 13:17:47 - INFO - Creating bagit.txt
2022/12/07 13:17:47 - INFO - Creating bag-info.txt
2022/12/07 13:17:47 - INFO - Generating manifest lines for file bag-info.txt
2022/12/07 13:17:47 - INFO - Generating manifest lines for file bagit.txt
2022/12/07 13:17:47 - INFO - Generating manifest lines for file manifest-sha256.txt
replaceafill@vm1:~/go-bagit$ go run ./main/ validate --bag /tmp/mybag
2022/12/07 13:17:51 - ERROR - /tmp/mybag/bag-info.txt did not contain a payload-oxum
```

The tag in `bag-info.txt` is created as `Payload_Oxum` but [`GetOxum` expects `Payload-Oxum`](https://github.com/nyudlts/go-bagit/blob/aa68a56947c52840cbda790dad2b2e1964055faa/oxum.go#L49)

Looking at the [Bagit RFC](https://www.rfc-editor.org/rfc/rfc8493) and specifically at the [bag-info.txt section](https://www.rfc-editor.org/rfc/rfc8493#section-2.2.2) I'd like to propose the metadata tags to be updated to use dashes instead of underscores.

Let me know what you think.