### PR TITLE
Use cut instead of split

### DIFF
--- a/oxum.go
+++ b/oxum.go
@@ -45,9 +45,9 @@ func GetOxum(bagLocation string) (string, error) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		splitLine := strings.Split(line, ":")
-		if splitLine[0] == "Payload-Oxum" {
-			return strings.TrimSpace(splitLine[1]), nil
+		before, after, _ := strings.Cut(line, ":")
+		if before == "Payload-Oxum" {
+			return strings.TrimSpace(after), nil
 		}
 	}
 

--- a/tags.go
+++ b/tags.go
@@ -47,8 +47,8 @@ func NewTagSet(filename string, bagLocation string) (TagSet, error) {
 
 	scanner := bufio.NewScanner(tagFile)
 	for scanner.Scan() {
-		kv := strings.Split(scanner.Text(), ": ")
-		tags[kv[0]] = kv[1]
+		before, after, _ := strings.Cut(scanner.Text(), ": ")
+		tags[before] = after
 	}
 
 	tagFile.Close()


### PR DESCRIPTION
The use of split could result in a weird bug if the ':' (colon) seperator is used in the value of part of a bagit.txt. It is also recommended to use this in the documentation for split.
