### PR TITLE
Update go.mod to use go 1.21 and toolchain 1.22.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/nyudlts/go-bagit
 
-go 1.21.4
+go 1.21
+
+toolchain go1.22.3
 
 require (
 	github.com/otiai10/copy v1.14.0
@@ -8,9 +10,9 @@ require (
 	gotest.tools/v3 v3.5.1
 )
 
-require github.com/google/go-cmp v0.5.9 // indirect
 
 require (
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sync v0.3.0 // indirect


### PR DESCRIPTION
This commit updates the `go.mod` file to set Go 1.21 as the minimum version requirement for compatibility with dependent modules, and specifies Go 1.22.3 as the preferred toolchain to ensure that this version is used when building binaries.

Setting the minimum version to go 1.21 instead of being explicit (e.g.: 1.21.3) allows dependents to upgrade at their own pace. This approach ensures they can use any patch release within the 1.21 series.